### PR TITLE
fix: self-heal leftover module directories and fail the build on clone errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ DEFAULT_PROJECT_NAME="$(project_name::resolve "$ENV_PATH" "$TEMPLATE_PATH")"
 ASSUME_YES=0
 FORCE_REBUILD=0
 SKIP_SOURCE_SETUP=0
+FRESH_MODULES=0
 CUSTOM_SOURCE_PATH=""
 
 show_build_header(){
@@ -38,6 +39,7 @@ Options:
   --force-update               Force update source repository to latest commits
   --source-path PATH           Custom source repository path
   --skip-source-setup          Skip automatic source repository setup
+  --fresh-modules              Discard and re-clone all enabled module repositories
   -h, --help                   Show this help
 
 This script handles:
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --force-update) FORCE_UPDATE=1; shift;;
     --source-path) CUSTOM_SOURCE_PATH="$2"; shift 2;;
     --skip-source-setup) SKIP_SOURCE_SETUP=1; shift;;
+    --fresh-modules) FRESH_MODULES=1; shift;;
     -h|--help) usage; exit 0;;
     *) err "Unknown option: $1"; usage; exit 1;;
   esac
@@ -512,6 +515,9 @@ stage_modules(){
   # Run module staging script in local modules directory
   export MODULES_LOCAL_RUN=1
   export MODULES_SKIP_SQL=1
+  if [ "${FRESH_MODULES:-0}" = "1" ]; then
+    export MODULES_FORCE_RECLONE=1
+  fi
   if [ -n "$staging_modules_dir" ]; then
     mkdir -p "$staging_modules_dir"
     rm -f "$staging_modules_dir/.modules_state" "$staging_modules_dir/.requires_rebuild" 2>/dev/null || true
@@ -564,6 +570,7 @@ stage_modules(){
   unset MODULES_LOCAL_RUN
   unset MODULES_SKIP_SQL
   unset MODULES_HOST_DIR
+  unset MODULES_FORCE_RECLONE
   [ -n "$git_temp_config" ] && [ -f "$git_temp_config" ] && rm -f "$git_temp_config"
 }
 

--- a/scripts/bash/manage-modules.sh
+++ b/scripts/bash/manage-modules.sh
@@ -30,6 +30,7 @@ DEFAULT_PROJECT_NAME="$(project_name::resolve "$ENV_PATH" "$TEMPLATE_FILE")"
 
 # Module-specific state
 PLAYERBOTS_DB_UPDATE_LOGGED=0
+MODULES_INSTALL_FAILED=0
 
 # Declare module metadata arrays globally at script level
 declare -A MODULE_NAME MODULE_REPO MODULE_REF MODULE_TYPE MODULE_ENABLED MODULE_NEEDS_BUILD MODULE_BLOCKED MODULE_POST_INSTALL MODULE_REQUIRES MODULE_CONFIG_CLEANUP MODULE_NOTES MODULE_STATUS MODULE_BLOCK_REASON
@@ -164,7 +165,45 @@ run_post_install_hooks(){
   done
 }
 
+# Checkout a pinned ref after a clone, warning on failure.
+checkout_module_ref(){
+  local dir="$1"
+  local ref="$2"
+  [ -n "$ref" ] || return 0
+  (cd "$dir" && git checkout "$ref") || warn "Unable to checkout ref $ref for $dir"
+}
+
+# Replace an existing module directory with a fresh clone. The old directory is
+# moved aside first and restored if the clone fails. Returns non-zero when the
+# directory could not be replaced.
+reclone_module_fresh(){
+  local dir="$1"
+  local repo="$2"
+  local ref="$3"
+  local stale_dir="${dir}.stale.$$"
+  if ! mv "$dir" "$stale_dir" 2>/dev/null; then
+    warn "Cannot replace $dir (parent directory not writable); leaving existing directory. Run scripts/bash/repair-storage-permissions.sh"
+    return 1
+  fi
+  if git clone "$repo" "$dir"; then
+    ok "$dir re-cloned fresh from remote"
+    if ! rm -rf "$stale_dir" 2>/dev/null && command -v docker >/dev/null 2>&1; then
+      docker run --rm -v "$(pwd)":/work -w /work "${ALPINE_IMAGE:-alpine:latest}" \
+        rm -rf "$stale_dir" >/dev/null 2>&1 || true
+    fi
+    if [ -d "$stale_dir" ]; then
+      warn "Could not remove old checkout at $stale_dir; remove it manually"
+    fi
+    checkout_module_ref "$dir" "$ref"
+    return 0
+  fi
+  err "Failed to re-clone $repo; restoring previous checkout"
+  mv "$stale_dir" "$dir" 2>/dev/null || err "Could not restore $dir from $stale_dir"
+  return 1
+}
+
 install_enabled_modules(){
+  local -a install_failures=()
   for key in "${MODULE_KEYS[@]}"; do
     if [ "${MODULE_ENABLED[$key]:-0}" != "1" ]; then
       continue
@@ -177,7 +216,10 @@ install_enabled_modules(){
       warn "Missing repository metadata for $key"
       continue
     fi
-    if [ -d "$dir/.git" ]; then
+    if [ "${MODULES_FORCE_RECLONE:-0}" = "1" ] && [ -d "$dir" ]; then
+      info "MODULES_FORCE_RECLONE=1: re-cloning $dir fresh"
+      reclone_module_fresh "$dir" "$repo" "$ref" || install_failures+=("$dir")
+    elif [ -d "$dir/.git" ]; then
       info "$dir already present; checking for updates"
       (cd "$dir" && git fetch origin >/dev/null 2>&1) || warn "Failed to fetch updates for $dir"
       local head_before head_after
@@ -211,41 +253,40 @@ install_enabled_modules(){
       fi
       if [ "$update_failed" -eq 1 ]; then
         warn "Failed to update $dir (checkout stuck at ${head_before}); re-cloning fresh"
-        local stale_dir="${dir}.stale.$$"
-        if mv "$dir" "$stale_dir" 2>/dev/null; then
-          if git clone "$repo" "$dir"; then
-            ok "$dir re-cloned fresh from remote"
-            if ! rm -rf "$stale_dir" 2>/dev/null && command -v docker >/dev/null 2>&1; then
-              docker run --rm -v "$(pwd)":/work -w /work "${ALPINE_IMAGE:-alpine:latest}" \
-                rm -rf "$stale_dir" >/dev/null 2>&1 || true
-            fi
-            if [ -d "$stale_dir" ]; then
-              warn "Could not remove old checkout at $stale_dir; remove it manually"
-            fi
-            if [ -n "$ref" ]; then
-              (cd "$dir" && git checkout "$ref") || warn "Unable to checkout ref $ref for $dir"
-            fi
-          else
-            err "Failed to re-clone $repo; restoring previous checkout"
-            mv "$stale_dir" "$dir" 2>/dev/null || err "Could not restore $dir from $stale_dir"
-          fi
-        else
-          warn "Cannot replace $dir (parent directory not writable); keeping checkout at ${head_before}. Run scripts/bash/repair-storage-permissions.sh"
-        fi
+        reclone_module_fresh "$dir" "$repo" "$ref" || true
       fi
     elif [ -d "$dir" ]; then
-      warn "$dir exists but is not a git repository; leaving in place"
+      # A directory without .git is a leftover from an interrupted clone or
+      # partial sync; recover it instead of leaving the module missing.
+      if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+        info "$dir exists but is empty; cloning ${dir} from ${repo}"
+        if git clone "$repo" "$dir"; then
+          checkout_module_ref "$dir" "$ref"
+        else
+          err "Failed to clone $repo"
+          install_failures+=("$dir")
+        fi
+      else
+        warn "$dir exists but is not a git repository; re-cloning fresh"
+        reclone_module_fresh "$dir" "$repo" "$ref" || install_failures+=("$dir")
+      fi
     else
       info "Cloning ${dir} from ${repo}"
-      if ! git clone "$repo" "$dir"; then
+      if git clone "$repo" "$dir"; then
+        checkout_module_ref "$dir" "$ref"
+      else
         err "Failed to clone $repo"
-      fi
-      if [ -n "$ref" ]; then
-        (cd "$dir" && git checkout "$ref") || warn "Unable to checkout ref $ref for $dir"
+        install_failures+=("$dir")
       fi
     fi
     run_post_install_hooks "$key" "$dir"
   done
+
+  if [ "${#install_failures[@]}" -gt 0 ]; then
+    err "Failed to install ${#install_failures[@]} module(s): ${install_failures[*]}"
+    err "Check network access to github.com and re-run to retry."
+    MODULES_INSTALL_FAILED=1
+  fi
 }
 
 
@@ -630,6 +671,10 @@ main(){
   # Build-time SQL staging has been removed as it created files that were never processed.
 
   track_module_state
+
+  if [ "${MODULES_INSTALL_FAILED:-0}" = "1" ]; then
+    fatal "Module management finished with clone failures; see errors above"
+  fi
 
   echo 'Module management complete.'
 


### PR DESCRIPTION
Fixes #29
Fixes #30

## Root cause

Both issues are the same underlying defect surfacing at different build stages. An interrupted `git clone` or partial sync (a SIGKILLed clone, an interrupted `rsync`/`cp -R`/`tar` staging pass) can leave module directories behind **without a `.git` folder**. `manage-modules.sh` treated those as terminal:

```
⚠️ mod-playerbots exists but is not a git repository; leaving in place
```

…and still **exited 0**, so `build.sh` considered staging successful and went on to compile. git never heals this on its own: `git clone` only deletes directories *it created*, so a pre-existing leftover dir blocks every future clone attempt.

The two symptoms:

- **Completely empty dir** (no `src/`): AzerothCore's CMake skips it, the module is silently absent, and a *dependent* module fails at compile time — `AiObjectContext.h: file not found` from mod-dungeon-clear when mod-playerbots was missing (#29).
- **Partial dir** (`src/` skeleton present, sources missing): CMake registers any `modules/<name>/src` directory and generates `Add<name>Scripts()` calls in `ModulesLoader.cpp` from the directory name alone, but nothing defines the symbol — the `undefined reference to 'Addmod_instance_resetScripts()'` link failures (#30). Notably the 10 failing modules there are alphabetically contiguous (mod-**i**nstance-reset → mod-**n**pc-subclass), the signature of an interrupted alphabetical bulk copy.

## Changes

**`scripts/bash/manage-modules.sh`**
- An **empty** module dir is now cloned into directly; a **non-empty non-git** dir is moved aside and re-cloned fresh, with the old directory restored if the clone fails. The previously duplicated stale-checkout re-clone logic is factored into a shared `reclone_module_fresh()` helper.
- Clone failures are collected and the script **exits non-zero** with a summary (`❌ Failed to install N module(s): …`), so `build.sh` aborts at "Module staging failed" instead of burning 30+ minutes compiling a broken tree. At runtime this also gates `ac-post-install` (it depends on `ac-modules` completing successfully).
- New `MODULES_FORCE_RECLONE=1` support: discard and re-clone every enabled module (old checkout kept until the fresh clone succeeds).

**`build.sh`**
- New `--fresh-modules` flag that sets `MODULES_FORCE_RECLONE=1` for the staging run. The container flow picks the same variable up from `.env` via `env_file`.

## Verification

Reproduced and verified against a local fixture repo with a minimal manifest:

1. Pre-existing empty module dir → previously warned + skipped (exit 0); now cloned. ✅
2. Non-empty non-git dir → moved aside and re-cloned fresh. ✅
3. Fresh clone with no existing dir → unchanged. ✅
4. Healthy existing checkout → update path unchanged (“already up to date”). ✅
5. Clone failure → exit 1 with failure summary. ✅
6. `MODULES_FORCE_RECLONE=1` → existing checkout replaced by fresh clone. ✅
7. Clone failure while recovering an empty dir → exit 1. ✅

`bash -n` and shellcheck pass with no new findings.

## Remediation for affected checkouts

```bash
# find damaged module checkouts
for d in local-storage/modules/mod-* local-storage/source/*/modules/mod-*; do
  [ -d "$d/.git" ] || echo "BAD: $d"
done

# with this PR: rebuild with a clean re-clone of all modules
./build.sh --fresh-modules
```